### PR TITLE
Resolve iOS 8 deprecation warnings as errors.

### DIFF
--- a/ABContact.m
+++ b/ABContact.m
@@ -670,22 +670,22 @@
 // No Image
 - (NSData *) baseDataRepresentation
 {
-	NSError *error;
-	NSDictionary *dict = [self baseDictionaryRepresentation];
+    NSError *error;
+    NSDictionary *dict = [self baseDictionaryRepresentation];
     NSData *data = [NSPropertyListSerialization dataWithPropertyList:dict format:NSPropertyListXMLFormat_v1_0 options:0 error:&error];
-	if (!data) MTLogError(@"Could not parse plist file correctly - error: %@", error);
-	return data; 
+    if (!data) MTLogError(@"Could not parse plist file correctly - error: %@", error);
+    return data;
 }
 
 
 // With image where available
 - (NSData *) dataRepresentation
 {
-	NSError *error;
-	NSDictionary *dict = [self dictionaryRepresentation];
+    NSError *error;
+    NSDictionary *dict = [self dictionaryRepresentation];
     NSData *data = [NSPropertyListSerialization dataWithPropertyList:dict format:NSPropertyListXMLFormat_v1_0 options:0 error:&error];
-	if (!data) MTLogError(@"Could not parse plist file correctly - error: %@", error);
-	return data;
+    if (!data) MTLogError(@"Could not parse plist file correctly - error: %@", error);
+    return data;
 }
 
 + (id) contactWithDictionary: (NSDictionary *) dict
@@ -731,19 +731,19 @@
 
 + (id) contactWithData: (NSData *) data
 {
-	// Otherwise handle points
-	CFErrorRef error;
+    // Otherwise handle points
+    CFErrorRef error;
     CFPropertyListFormat format;
     CFPropertyListRef plist = CFPropertyListCreateWithData(kCFAllocatorDefault, (CFDataRef)data, kCFPropertyListMutableContainers, &format, &error);
-	if (!plist) 
-	{
-		MTLogError(@"Could not serialize NSData into plist file correctly - error: %@", error);
-		return nil;
-	}
-	
-	NSDictionary *dict = (NSDictionary *) plist;
-	[dict autorelease];
-	
-	return [self contactWithDictionary:dict];
+    if (!plist)
+    {
+        MTLogError(@"Could not serialize NSData into plist file correctly - error: %@", error);
+        return nil;
+    }
+    
+    NSDictionary *dict = (NSDictionary *) plist;
+    [dict autorelease];
+    
+    return [self contactWithDictionary:dict];
 }
 @end

--- a/ABContact.m
+++ b/ABContact.m
@@ -670,10 +670,10 @@
 // No Image
 - (NSData *) baseDataRepresentation
 {
-	NSString *errorString;
+	NSError *error;
 	NSDictionary *dict = [self baseDictionaryRepresentation];
-	NSData *data = [NSPropertyListSerialization dataFromPropertyList:dict format:NSPropertyListXMLFormat_v1_0 errorDescription:&errorString];
-	if (!data) CFShow(errorString);
+    NSData *data = [NSPropertyListSerialization dataWithPropertyList:dict format:NSPropertyListXMLFormat_v1_0 options:0 error:&error];
+	if (!data) MTLogError(@"Could not parse plist file correctly - error: %@", error);
 	return data; 
 }
 
@@ -681,10 +681,10 @@
 // With image where available
 - (NSData *) dataRepresentation
 {
-	NSString *errorString;
+	NSError *error;
 	NSDictionary *dict = [self dictionaryRepresentation];
-	NSData *data = [NSPropertyListSerialization dataFromPropertyList:dict format:NSPropertyListXMLFormat_v1_0 errorDescription:&errorString];
-	if (!data) CFShow(errorString);
+    NSData *data = [NSPropertyListSerialization dataWithPropertyList:dict format:NSPropertyListXMLFormat_v1_0 options:0 error:&error];
+	if (!data) MTLogError(@"Could not parse plist file correctly - error: %@", error);
 	return data;
 }
 
@@ -732,11 +732,12 @@
 + (id) contactWithData: (NSData *) data
 {
 	// Otherwise handle points
-	CFStringRef errorString;
-	CFPropertyListRef plist = CFPropertyListCreateFromXMLData(kCFAllocatorDefault, (CFDataRef)data, kCFPropertyListMutableContainers, &errorString);
+	CFErrorRef error;
+    CFPropertyListFormat format;
+    CFPropertyListRef plist = CFPropertyListCreateWithData(kCFAllocatorDefault, (CFDataRef)data, kCFPropertyListMutableContainers, &format, &error);
 	if (!plist) 
 	{
-		CFShow(errorString);
+		MTLogError(@"Could not serialize NSData into plist file correctly - error: %@", error);
 		return nil;
 	}
 	


### PR DESCRIPTION
As a result of moving to iOS 8 min. deployment target, these changes are needed since we build with warnings as errors.
